### PR TITLE
fix: error: inappropriate value for attribute 'forward': string required

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -107,8 +107,6 @@ variable "default_cache_behavior_forward_headers" {
 }
 
 variable "default_cache_behavior_cookies_forward" {
-  default     = ["all"]
+  default     = "all"
   description = "Default cache behavior cookies forward"
 }
-
-


### PR DESCRIPTION
This Pull Request Fixes this error:

```
Error: Incorrect attribute value type
  on .terraform/modules/barbooks_frontend/cloudfront.tf line 87, in resource "aws_cloudfront_distribution" "default":
  87:         forward             = var.default_cache_behavior_cookies_forward
    |----------------
    | var.default_cache_behavior_cookies_forward is tuple with 1 element
Inappropriate value for attribute "forward": string required.
```

Accordingly the documentation the value should be a string.

Source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forward